### PR TITLE
String buffer scanner using apache commons csv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>uk.ac.ed.datashare.rest</groupId>
 	<artifactId>datashare-preview</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>datashare-preview</name>
 	<description>Preview of files REST web application</description>
@@ -44,6 +44,14 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-csv -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.9.0</version>
+		</dependency>
+
 
 	</dependencies>
 

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
@@ -1,6 +1,7 @@
 package uk.ac.ed.datashare.rest.preview;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -16,7 +17,6 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
 
-import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -55,7 +55,22 @@ public class PreviewController {
 			String encoding = detectEncoding(url.openStream());
 			encoding = encoding != null ? encoding : "UTF-8";
 
-			reader = new InputStreamReader(new BOMInputStream(url.openStream()), encoding);
+			@SuppressWarnings("resource")
+			Scanner scnr = new Scanner(url.openStream(), encoding);
+			// read from your scanner
+			int lineNumber = 1;
+			StringBuffer sb = new StringBuffer();
+
+			while(scnr.hasNextLine() && lineNumber <= maxNumOfRecordsToPreview + 5 ){
+				String line = scnr.nextLine();
+				line += "\n";
+				sb.append(line);
+				lineNumber++;
+			}
+            // Set Scanner to null
+			scnr = null;
+
+			reader = new InputStreamReader(new BOMInputStream(new ByteArrayInputStream(sb.toString().getBytes())), encoding);
 
 			parser = new CSVParser(reader, CSVFormat.EXCEL.withHeader().withSkipHeaderRecord(false));
 

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
@@ -3,10 +3,16 @@ package uk.ac.ed.datashare.rest.preview;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URL;
+import java.util.List;
 import java.util.Scanner;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
 
@@ -27,7 +33,7 @@ import com.ibm.icu.text.CharsetMatch;
 @RestController
 public class PreviewController {
 
-	private int maxNumOfLinesToPreview = 13;
+	private int maxNumOfRecordsToPreview = 20;
 	private final AtomicLong counter = new AtomicLong();
 
 
@@ -36,9 +42,11 @@ public class PreviewController {
 	@PostMapping(path = "/preview",
 	consumes = MediaType.APPLICATION_JSON_VALUE,
 	produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<Preview> previewPost(@RequestBody FileInfo fileInfo) {
+	public ResponseEntity<Preview> previewPost(@RequestBody FileInfo fileInfo) throws IOException {
 		String msg = "";
 		String fullFileUrl = "";
+		Reader reader = null;
+		CSVParser parser = null;
 
 		try {
 			fullFileUrl = fileInfo.getFileUrl();
@@ -47,42 +55,57 @@ public class PreviewController {
 			String encoding = detectEncoding(url.openStream());
 			encoding = encoding != null ? encoding : "UTF-8";
 
-			@SuppressWarnings("resource")
-			Scanner scnr = new Scanner(url.openStream(), encoding);
-			// read from your scanner
-			int lineNumber = 1;
-			while(scnr.hasNextLine() && lineNumber <= maxNumOfLinesToPreview){
-				String line = scnr.nextLine();
-				msg += line + "\n";
-				lineNumber++;
+			reader = new InputStreamReader(new BOMInputStream(url.openStream()), encoding);
 
+			parser = new CSVParser(reader, CSVFormat.EXCEL.withHeader().withSkipHeaderRecord(false));
+
+			List<String> headers = parser.getHeaderNames();
+			String headerString = "";
+			for (String header: headers) {
+				int colNumber = 1;
+				headerString += header.replace(",", "&#44;");
+				if(colNumber < headers.size()) {
+					headerString += ",";
+				}
+				colNumber++;	
+			}
+			msg += headerString + "\n";
+
+			int recordNumber = 1;
+			while(recordNumber <= maxNumOfRecordsToPreview) {
+				for (final CSVRecord record : parser) {
+					String rowString = "";
+					int colNumber = 1;
+					for(String col: record) {
+						rowString += col.replace(",", "&#44;");
+						if(colNumber < record.size()) {
+							rowString += ",";
+						}
+						colNumber++;	
+					}
+					msg += rowString + "\n";
+					recordNumber++;
+				}
 			}
 
-
 		}
-		catch(IOException ex) {
+		catch(Exception ex) {
 			// there was some connection problem, or the file did not exist on the server,
 			// or your URL was not in the right format.
 			// think about what to do now, and put it here.
 			ex.printStackTrace(); // for now, simply output it.
 		}
+		finally {
+			try {
+				parser.close();
+			} catch (Exception e) {}
+			try {
+				reader.close();
+			} catch(Exception e) {}
+		}
+
 
 		return new ResponseEntity<>(new Preview(counter.incrementAndGet(), msg, fullFileUrl), HttpStatus.OK);
-	}
-
-	// From https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
-	private String cleanTextContent(String text) 
-	{
-		// strips off all non-ASCII characters
-		text = text.replaceAll("[^\\x00-\\x7F]", "");
-
-		// erases all the ASCII control characters
-		//	    text = text.replaceAll("[\\p{Cntrl}&&[^\r\n\t]]", "");
-
-		// removes non-printable characters from Unicode
-		//	    text = text.replaceAll("\\p{C}", "");
-
-		return text.trim();
 	}
 
 	// Java: How To Autodetect The Charset Encoding of A 


### PR DESCRIPTION
This is upgrade of current preview in main, using the more robust Apache Commons CSV library for parsing the lines.

To ensure we read only a small number of lines and not pull all the data into memory. We use the Scanner class as was done previously to read a limited number of lines. We then parse these lines using the Apache Commons CSV parser.