### PR TITLE
Refactoring preview code to use java 7 and 8 features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.6</version>
+		<version>2.7.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>uk.ac.ed.datashare.rest</groupId>
@@ -22,6 +20,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -50,6 +54,12 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
 			<version>1.9.0</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-log4j2 -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-log4j2</artifactId>
 		</dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>uk.ac.ed.datashare.rest</groupId>
 	<artifactId>datashare-preview</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>datashare-preview</name>
 	<description>Preview of files REST web application</description>

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/Preview.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/Preview.java
@@ -1,7 +1,5 @@
 package uk.ac.ed.datashare.rest.preview;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 public class Preview {
 
 	private long id;

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
@@ -29,6 +29,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ibm.icu.text.CharsetDetector;
 import com.ibm.icu.text.CharsetMatch;
 
+import uk.ac.ed.datashare.rest.preview.domains.FileInfo;
+import uk.ac.ed.datashare.rest.preview.domains.Preview;
+
 @RestController
 public class PreviewController {
 

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/PreviewController.java
@@ -16,8 +16,8 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
-
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -29,14 +29,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ibm.icu.text.CharsetDetector;
 import com.ibm.icu.text.CharsetMatch;
 
-
 @RestController
 public class PreviewController {
 
+	private static final Logger logger = LoggerFactory.getLogger(PreviewController.class);
 	private int maxNumOfRecordsToPreview = 20;
 	private final AtomicLong counter = new AtomicLong();
-
-
 
 	@CrossOrigin
 	@PostMapping(path = "/preview",
@@ -51,9 +49,13 @@ public class PreviewController {
 		try {
 			fullFileUrl = fileInfo.getFileUrl();
 			URL url = new URL(fullFileUrl);
+			
+			logger.debug("fullFileUrl: " + fullFileUrl);
 
 			String encoding = detectEncoding(url.openStream());
 			encoding = encoding != null ? encoding : "UTF-8";
+			
+			logger.debug("encoding: " + encoding);
 
 			@SuppressWarnings("resource")
 			Scanner scnr = new Scanner(url.openStream(), encoding);
@@ -119,7 +121,7 @@ public class PreviewController {
 			} catch(Exception e) {}
 		}
 
-
+		logger.debug("Response data msg is NOT EMPTY: " + !msg.isEmpty());
 		return new ResponseEntity<>(new Preview(counter.incrementAndGet(), msg, fullFileUrl), HttpStatus.OK);
 	}
 

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/controllers/PreviewController.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/controllers/PreviewController.java
@@ -1,24 +1,10 @@
 package uk.ac.ed.datashare.rest.preview.controllers;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.net.URL;
-import java.util.List;
-import java.util.Scanner;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.apache.commons.io.ByteOrderMark;
-import org.apache.commons.io.input.BOMInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -26,118 +12,21 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ibm.icu.text.CharsetDetector;
-import com.ibm.icu.text.CharsetMatch;
-
 import uk.ac.ed.datashare.rest.preview.domains.FileInfo;
 import uk.ac.ed.datashare.rest.preview.domains.Preview;
+import uk.ac.ed.datashare.rest.preview.services.TextFileService;
 
 @RestController
 public class PreviewController {
+	
+	 @Autowired 
+	 private TextFileService textFileService;
 
 	private static final Logger logger = LoggerFactory.getLogger(PreviewController.class);
-	private int maxNumOfRecordsToPreview = 20;
-	private final AtomicLong counter = new AtomicLong();
-
+	
 	@CrossOrigin
 	@PostMapping(path = "/preview", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Preview> previewPost(@RequestBody FileInfo fileInfo) throws IOException {
-		String msg = "";
-		String fullFileUrl = "";
-
-		try {
-			fullFileUrl = fileInfo.getFileUrl();
-			URL url = new URL(fullFileUrl);
-
-			logger.debug("fullFileUrl: " + fullFileUrl);
-
-			String encoding = "UTF-8"; // Default
-			try (InputStream urlOpenStreamForGettingEncoding = url.openStream()) {
-				encoding = detectEncoding(urlOpenStreamForGettingEncoding);
-				encoding = encoding != null ? encoding : "UTF-8";
-			}
-
-			logger.debug("encoding: " + encoding);
-
-			try (InputStream urlOpenStreamForData = url.openStream()) {
-				@SuppressWarnings("resource")
-				Scanner scnr = new Scanner(urlOpenStreamForData, encoding);
-				// read from your scanner
-				int lineNumber = 1;
-				StringBuffer sb = new StringBuffer();
-
-				while (scnr.hasNextLine() && lineNumber <= maxNumOfRecordsToPreview + 5) {
-					String line = scnr.nextLine();
-					line += "\n";
-					sb.append(line);
-					lineNumber++;
-				}
-				// Set Scanner to null
-				scnr = null;
-
-				try (Reader reader = new InputStreamReader(
-						new BOMInputStream(new ByteArrayInputStream(sb.toString().getBytes())), encoding);
-						CSVParser parser = new CSVParser(reader,
-								CSVFormat.EXCEL.withHeader().withSkipHeaderRecord(false));) {
-
-					List<String> headers = parser.getHeaderNames();
-					String headerString = "";
-					for (String header : headers) {
-						int colNumber = 1;
-						headerString += header.replace(",", "&#44;");
-						if (colNumber < headers.size()) {
-							headerString += ",";
-						}
-						colNumber++;
-					}
-					msg += headerString + "\n";
-
-					int recordNumber = 1;
-					while (recordNumber <= maxNumOfRecordsToPreview) {
-						for (final CSVRecord record : parser) {
-							String rowString = "";
-							int colNumber = 1;
-							for (String col : record) {
-								rowString += col.replace(",", "&#44;");
-								if (colNumber < record.size()) {
-									rowString += ",";
-								}
-								colNumber++;
-							}
-							msg += rowString + "\n";
-							recordNumber++;
-						}
-					}
-				}
-			}
-		} catch (Exception ex) {
-			// there was some connection problem, or the file did not exist on the server,
-			// or your URL was not in the right format.
-			// think about what to do now, and put it here.
-			ex.printStackTrace(); // for now, simply output it.
-		}
-
-		logger.debug("Response data msg is NOT EMPTY: " + !msg.isEmpty());
-		return new ResponseEntity<>(new Preview(counter.incrementAndGet(), msg, fullFileUrl), HttpStatus.OK);
-	}
-
-	// Java: How To Autodetect The Charset Encoding of A
-	// Text File and Remove Byte Order Mark (BOM).
-	// https://fahri.id/posts/java-how-to-autodetect-the-charset/
-	private String detectEncoding(InputStream inputStream) {
-		try (BOMInputStream bomInputStream = new BOMInputStream(new BufferedInputStream(inputStream),
-				ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE,
-				ByteOrderMark.UTF_32LE)) {
-
-			CharsetDetector detector = new CharsetDetector();
-			detector.setText(bomInputStream);
-
-			CharsetMatch charsetMatch = detector.detect();
-			System.out.println("CHARSET MATCH : " + charsetMatch.getName());
-
-			return charsetMatch.getName();
-		} catch (Exception e) {
-			return "UTF-8";
-		}
+		return textFileService.previewTextFile(fileInfo);
 	}
 }

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/controllers/PreviewController.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/controllers/PreviewController.java
@@ -1,4 +1,4 @@
-package uk.ac.ed.datashare.rest.preview;
+package uk.ac.ed.datashare.rest.preview.controllers;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/domains/FileInfo.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/domains/FileInfo.java
@@ -1,4 +1,4 @@
-package uk.ac.ed.datashare.rest.preview;
+package uk.ac.ed.datashare.rest.preview.domains;
 
 public class FileInfo {
 	

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/domains/Preview.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/domains/Preview.java
@@ -1,4 +1,4 @@
-package uk.ac.ed.datashare.rest.preview;
+package uk.ac.ed.datashare.rest.preview.domains;
 
 public class Preview {
 

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/services/TextFileService.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/services/TextFileService.java
@@ -1,0 +1,13 @@
+package uk.ac.ed.datashare.rest.preview.services;
+
+import java.io.IOException;
+
+import org.springframework.http.ResponseEntity;
+
+import uk.ac.ed.datashare.rest.preview.domains.FileInfo;
+import uk.ac.ed.datashare.rest.preview.domains.Preview;
+
+public interface TextFileService {
+	
+	public ResponseEntity<Preview> previewTextFile(FileInfo fileInfo) throws IOException;
+}

--- a/src/main/java/uk/ac/ed/datashare/rest/preview/services/TextFileServiceImpl.java
+++ b/src/main/java/uk/ac/ed/datashare/rest/preview/services/TextFileServiceImpl.java
@@ -1,0 +1,139 @@
+package uk.ac.ed.datashare.rest.preview.services;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.util.List;
+import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.ibm.icu.text.CharsetDetector;
+import com.ibm.icu.text.CharsetMatch;
+
+import uk.ac.ed.datashare.rest.preview.domains.FileInfo;
+import uk.ac.ed.datashare.rest.preview.domains.Preview;
+
+@Service
+public class TextFileServiceImpl implements TextFileService {
+
+	private static final Logger logger = LoggerFactory.getLogger(TextFileServiceImpl.class);
+	private int maxNumOfRecordsToPreview = 20;
+	private final AtomicLong counter = new AtomicLong();
+
+	@Override
+	public ResponseEntity<Preview> previewTextFile(FileInfo fileInfo) throws IOException {
+			String msg = "";
+		String fullFileUrl = "";
+
+		try {
+			fullFileUrl = fileInfo.getFileUrl();
+			URL url = new URL(fullFileUrl);
+
+			logger.debug("fullFileUrl: " + fullFileUrl);
+
+			String encoding = "UTF-8"; // Default
+			try (InputStream urlOpenStreamForGettingEncoding = url.openStream()) {
+				encoding = detectEncoding(urlOpenStreamForGettingEncoding);
+				encoding = encoding != null ? encoding : "UTF-8";
+			}
+
+			logger.debug("encoding: " + encoding);
+
+			try (InputStream urlOpenStreamForData = url.openStream()) {
+				@SuppressWarnings("resource")
+				Scanner scnr = new Scanner(urlOpenStreamForData, encoding);
+				// read from your scanner
+				int lineNumber = 1;
+				StringBuffer sb = new StringBuffer();
+
+				while (scnr.hasNextLine() && lineNumber <= maxNumOfRecordsToPreview + 5) {
+					String line = scnr.nextLine();
+					line += "\n";
+					sb.append(line);
+					lineNumber++;
+				}
+				// Set Scanner to null
+				scnr = null;
+
+				try (Reader reader = new InputStreamReader(
+						new BOMInputStream(new ByteArrayInputStream(sb.toString().getBytes())), encoding);
+						CSVParser parser = new CSVParser(reader,
+								CSVFormat.EXCEL.withHeader().withSkipHeaderRecord(false));) {
+
+					List<String> headers = parser.getHeaderNames();
+					String headerString = "";
+					for (String header : headers) {
+						int colNumber = 1;
+						headerString += header.replace(",", "&#44;");
+						if (colNumber < headers.size()) {
+							headerString += ",";
+						}
+						colNumber++;
+					}
+					msg += headerString + "\n";
+
+					int recordNumber = 1;
+					while (recordNumber <= maxNumOfRecordsToPreview) {
+						for (final CSVRecord record : parser) {
+							String rowString = "";
+							int colNumber = 1;
+							for (String col : record) {
+								rowString += col.replace(",", "&#44;");
+								if (colNumber < record.size()) {
+									rowString += ",";
+								}
+								colNumber++;
+							}
+							msg += rowString + "\n";
+							recordNumber++;
+						}
+					}
+				}
+			}
+		} catch (Exception ex) {
+			// there was some connection problem, or the file did not exist on the server,
+			// or your URL was not in the right format.
+			// think about what to do now, and put it here.
+			ex.printStackTrace(); // for now, simply output it.
+		}
+
+		logger.debug("Response data msg is NOT EMPTY: " + !msg.isEmpty());
+		return new ResponseEntity<>(new Preview(counter.incrementAndGet(), msg, fullFileUrl), HttpStatus.OK);
+	}
+
+	// Java: How To Autodetect The Charset Encoding of A
+	// Text File and Remove Byte Order Mark (BOM).
+	// https://fahri.id/posts/java-how-to-autodetect-the-charset/
+	private String detectEncoding(InputStream inputStream) {
+		try (BOMInputStream bomInputStream = new BOMInputStream(new BufferedInputStream(inputStream),
+				ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE,
+				ByteOrderMark.UTF_32LE)) {
+
+			CharsetDetector detector = new CharsetDetector();
+			detector.setText(bomInputStream);
+
+			CharsetMatch charsetMatch = detector.detect();
+			System.out.println("CHARSET MATCH : " + charsetMatch.getName());
+
+			return charsetMatch.getName();
+		} catch (Exception e) {
+			return "UTF-8";
+		}
+	}
+
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG" monitorInterval="30">
+  <Properties>
+    <Property name="LOG_PATTERN">%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ} %p %m%n</Property>
+    <Property name="APP_LOG_ROOT">logs</Property>
+  </Properties>
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT" follow="true">
+      <PatternLayout pattern="${LOG_PATTERN}" />
+    </Console>
+ 
+    <RollingFile name="appLog"
+      fileName="${APP_LOG_ROOT}/datashare-preview.log"
+      filePattern="${APP_LOG_ROOT}/datashare-preview-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout pattern="${LOG_PATTERN}" />
+      <Policies>
+        <SizeBasedTriggeringPolicy size="19500KB" />
+      </Policies>
+      <DefaultRolloverStrategy max="1" />
+    </RollingFile>
+ 
+  </Appenders>
+  <Loggers>
+ 
+    <Logger name="uk.ac.ed.datashare" additivity="false">
+      <AppenderRef ref="appLog" />
+      <AppenderRef ref="Console" />
+    </Logger>
+ 
+    <Root level="debug">
+      <AppenderRef ref="Console" />
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
The changes are:
- Added Log4j2 logging. That writes datashare-preview.log to the logs folder of server like Tomcat. Update Spring Boot version here to Spring Boot v2.7.1
- Updated POM version to 0.0.3-SNAPSHOT 
- Updated code to use Java 7 try-with-resources feature to reduce redundant finally blocks to close streams.
- Refactored code to create a domains package.
- Refactored code to create a controllers package.
-  Refactored code in controller to service layer.

Snippet of log:

> 2022-06-28T11:45:50.609+0100 INFO Starting SpringBootTomcatApplication v0.0.3-SNAPSHOT using Java 1.8.0_312 on newington with PID 8235 (/home/jpinto/TOMCAT-WS/apache-tomcat-8.5.73/webapps/datashare-preview/WEB-INF/classes started by jpinto in /home/jpinto/TOMCAT-WS/apache-tomcat-8.5.73)
> 2022-06-28T11:45:50.611+0100 DEBUG Running with Spring Boot v2.7.1, Spring v5.3.21
> 2022-06-28T11:45:50.611+0100 INFO No active profile set, falling back to 1 default profile: "default"
> 2022-06-28T11:45:51.462+0100 INFO Started SpringBootTomcatApplication in 1.087 seconds (JVM running for 2.688)
> 2022-06-28T11:46:20.027+0100 DEBUG fullFileUrl: https://datashare.ed.ac.uk/bitstream/handle/10283/4375/Plot%20data%20for%20McNemar%20test.csv?sequence=1&isAllowed=y
> 2022-06-28T11:46:20.224+0100 DEBUG encoding: ISO-8859-1
> 2022-06-28T11:46:20.260+0100 DEBUG Response data msg is NOT EMPTY: true

