### PR TITLE
The log4j2 log root set as /home/lib/dspace/apache-tomcat-9.0.12/logs

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,8 @@
 <Configuration status="DEBUG" monitorInterval="30">
   <Properties>
     <Property name="LOG_PATTERN">%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ} %p %m%n</Property>
-    <Property name="APP_LOG_ROOT">logs</Property>
+    <!-- Log root set for Datashare VMs -->
+    <Property name="APP_LOG_ROOT">/home/lib/dspace/apache-tomcat-9.0.12/logs</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">


### PR DESCRIPTION
which is the current Tomcat log directory on the Datashare VMs.